### PR TITLE
FEAT: apply noises on dots

### DIFF
--- a/Assets/Scripts/MapGenerator/MapDot.cs
+++ b/Assets/Scripts/MapGenerator/MapDot.cs
@@ -4,6 +4,18 @@ namespace MapGenerator
 {
     public class Dot : MonoBehaviour
     {
+        public float temperature;
 
+        public void SetTemperature(float temperature)
+        {
+            this.temperature = temperature;
+        }
+
+        public void SetYPosition(float y)
+        {
+            Vector3 pos = transform.position;
+            pos.y = y;
+            transform.position = pos;
+        }
     }
 }

--- a/Assets/Scripts/MapGenerator/MapGenerator.cs
+++ b/Assets/Scripts/MapGenerator/MapGenerator.cs
@@ -12,10 +12,38 @@ namespace MapGenerator
         [SerializeField] private float mapDimension = 1f;
         public int nbDotsPerLine = 30;
         private GameObject meshMap;
+        private Texture2D heightMap;
+        private Texture2D temperatureMap;
+        private List<float> heightMapValues;
+        private List<float> temperatureMapValues;
+        public float perlinScale = 20f;
+        public float emplitude = 10f;
 
         private void Start()
         {
+            GenerateAll();
+        }
+
+        public void GenerateAll()
+        {
             GenerateDots();
+
+            heightMapValues = PerlinNoiseHeightMapGenerator.GenerateHeightMapTexture(nbDotsPerLine, nbDotsPerLine, perlinScale, out heightMap, false);
+            temperatureMapValues = PerlinNoiseHeightMapGenerator.GenerateHeightMapTexture(nbDotsPerLine, nbDotsPerLine, perlinScale, out temperatureMap, false);
+
+            for (int x = 0; x < mapDots.Count; x++)
+            {
+                for (int z = 0; z < mapDots[x].Count; z++)
+                {
+                    float height = heightMapValues[x * nbDotsPerLine + z] / emplitude;
+                    float temperature = temperatureMapValues[x * nbDotsPerLine + z];
+
+                    mapDots[x][z].SetYPosition(height);
+                    mapDots[x][z].SetTemperature(temperature);
+                }
+            }
+
+            CreateMesh();
         }
 
         private void GenerateDots()
@@ -104,9 +132,14 @@ namespace MapGenerator
                 map.CreateMesh();
             }
 
+            if (GUILayout.Button("Generate All"))
+            {
+                map.GenerateAll();
+            }
+
             if (GUILayout.Button("Generate Heightmap"))
             {
-                PerlinNoiseHeightMapGenerator.GenerateHeightMapTexture(map.nbDotsPerLine, map.nbDotsPerLine, out Texture2D _, true);
+                PerlinNoiseHeightMapGenerator.GenerateHeightMapTexture(map.nbDotsPerLine, map.nbDotsPerLine, map.perlinScale, out Texture2D _, true);
             }
         }
     }

--- a/Assets/Scripts/PerlinNoiseHeightMapGenerator/PerlinNoiseHeightMapGenerator.cs
+++ b/Assets/Scripts/PerlinNoiseHeightMapGenerator/PerlinNoiseHeightMapGenerator.cs
@@ -4,14 +4,13 @@ using UnityEngine;
 
 public class PerlinNoiseHeightMapGenerator : MonoBehaviour
 {
-    [HideInInspector] public static float scale = 20f;
     [HideInInspector] public static float randomOffsetRange = 100f;
     private readonly static string folderName = "Heightmaps";
 
-    public static List<float> GenerateHeightMapTexture(int width, int height, out Texture2D texture, bool saveHasFile = false)
+    public static List<float> GenerateHeightMapTexture(int width, int height, float scale, out Texture2D texture, bool saveHasFile = false)
     {
-        List<float> heightMap = GenerateHeightMap(width, height);
-        texture = GenerateTexture(width, height, heightMap);
+        List<float> heightMap = GenerateHeightMap(width, height, scale);
+        texture = GenerateTexture(width, height, scale, heightMap);
 
         if (!saveHasFile) return heightMap;
 
@@ -31,7 +30,7 @@ public class PerlinNoiseHeightMapGenerator : MonoBehaviour
         return heightMap;
     }
 
-    static Texture2D GenerateTexture(int width, int height, List<float> heightMap)
+    static Texture2D GenerateTexture(int width, int height, float scale, List<float> heightMap)
     {
         Texture2D texture = new(width, height);
         int index = 0;
@@ -51,7 +50,7 @@ public class PerlinNoiseHeightMapGenerator : MonoBehaviour
         return texture;
     }
 
-    static List<float> GenerateHeightMap(int width, int height)
+    static List<float> GenerateHeightMap(int width, int height, float scale)
     {
         List<float> heightMap = new();
 


### PR DESCRIPTION
- Applique les bruits de Perlin de température et de hauteur aux points.
- Ajoute un bouton à l'interface pour générer tout d'un coup (points, bruits, applications des bruits, génération du mesh)
- Ajout d'un attribut "perlinScale" qui permet de changer le comportement du bruit (plus scale est petit, plus le bruit sera composé de grandes surfaces)
- Ajout d'un attribut "emplitude". Par défaut, les points sont générés entre 0 et 1, qui sont des valeurs trop grandes pour notre échelle. Une division de la hauteur par l'amplitude permet de choisir à quel point les montagnes sont hautes et les crevasses basses.

Il faudra voir pour définir arbitrairement le niveau de la mer par la suite.

(déso Cyril, j'te pique ton ticket, j'en ai besoin pour le mien)