### PR TITLE
FIX: clamp heightmap texture + object position shader

### DIFF
--- a/Assets/Scripts/MapGenerator/PerlinNoiseHeightMapGenerator.cs
+++ b/Assets/Scripts/MapGenerator/PerlinNoiseHeightMapGenerator.cs
@@ -46,6 +46,7 @@ public class PerlinNoiseHeightMapGenerator : MonoBehaviour
         }
 
         texture.Apply();
+        texture.wrapMode = TextureWrapMode.Clamp;
 
         return texture;
     }

--- a/Assets/Shaders/Biomes/BiomesGradientToon.shadergraph
+++ b/Assets/Shaders/Biomes/BiomesGradientToon.shadergraph
@@ -4988,7 +4988,7 @@
     "m_CustomColors": {
         "m_SerializableColors": []
     },
-    "m_Space": 2,
+    "m_Space": 0,
     "m_PositionSource": 0
 }
 
@@ -8593,7 +8593,7 @@
     "m_CustomColors": {
         "m_SerializableColors": []
     },
-    "m_Space": 2,
+    "m_Space": 0,
     "m_PositionSource": 0
 }
 


### PR DESCRIPTION
Les couleurs du shader des biomes ne dépend plus de la position de la carte dans l'espace