### PR TITLE
FIX: show less dots when tools action for quest 3 performances

### DIFF
--- a/Assets/Scripts/Tools/ToolsActions/ChangeHeight.cs
+++ b/Assets/Scripts/Tools/ToolsActions/ChangeHeight.cs
@@ -27,7 +27,7 @@ public class ChangeHeight : ToolAction
             {
                 float newY = selectedDot.dot.transform.position.y + moveValue * direction * pressure;
                 selectedDot.dot.SetYPosition(newY);
-                if (showSelectedDots) selectedDot.dot.gameObject.SetActive(true);
+                if (showSelectedDots && circleIndex == selectedDots.surroundingCircles.Count - 1) selectedDot.dot.gameObject.SetActive(true);
                 if (selectedDot.dot.element)
                     selectedDot.dot.element.transform.position = selectedDot.dot.transform.position;
             }

--- a/Assets/Scripts/Tools/ToolsActions/ChangeTemperature.cs
+++ b/Assets/Scripts/Tools/ToolsActions/ChangeTemperature.cs
@@ -24,7 +24,7 @@ public class ChangeTemperature : ToolAction
             foreach (SelectedDot selectedDot in currentCircle)
             {
                 selectedDot.dot.SetTemperature(selectedDot.dot.temperature + moveValue * direction * pressure);
-                if (showSelectedDots) selectedDot.dot.gameObject.SetActive(true);
+                if (showSelectedDots && circleIndex == selectedDots.surroundingCircles.Count - 1) selectedDot.dot.gameObject.SetActive(true);
                 ElementsSpawner.Instance.UpdatePrefab(selectedDot.dot);
             }
         }

--- a/Assets/Scripts/Tools/ToolsActions/Flatten.cs
+++ b/Assets/Scripts/Tools/ToolsActions/Flatten.cs
@@ -24,8 +24,9 @@ public class Flatten : ToolAction
                 int dotIndex = currentCircle.IndexOf(selectedDot);
                 int nummberOfDots = currentCircle.Count;
                 float moveValue = Mathf.Lerp(currentY, finalY, (float)(dotIndex + 1) / nummberOfDots);
+
                 selectedDot.dot.SetYPosition(moveValue);
-                if (showSelectedDots) selectedDot.dot.gameObject.SetActive(true);
+                if (showSelectedDots && circleIndex == selectedDots.surroundingCircles.Count - 1) selectedDot.dot.gameObject.SetActive(true);
                 if (selectedDot.dot.element)
                     selectedDot.dot.element.transform.position = selectedDot.dot.transform.position;
             }

--- a/Assets/Scripts/Tools/ToolsActions/SmoothHeight.cs
+++ b/Assets/Scripts/Tools/ToolsActions/SmoothHeight.cs
@@ -28,7 +28,7 @@ public class SmoothHeight : ToolAction
                 float smoothedY = Mathf.Lerp(currentY, finalY, smoothingFactor * Time.deltaTime);
 
                 selectedDot.dot.SetYPosition(smoothedY);
-                if (showSelectedDots) selectedDot.dot.gameObject.SetActive(true);
+                if (showSelectedDots && circleIndex == selectedDots.surroundingCircles.Count - 1) selectedDot.dot.gameObject.SetActive(true);
                 if (selectedDot.dot.element)
                     selectedDot.dot.element.transform.position = selectedDot.dot.transform.position;
             }


### PR DESCRIPTION
Au lieu de montrer tous les points, il n'y a que le point central et le dernier cercle. Je fais un test ce soir pour voir si ça lag trop. Si c'est pas bon, je n'activerais que le point central